### PR TITLE
Fix building (Tested against a Ubuntu 22.04 target on OBS)

### DIFF
--- a/network:retroshare/retroshare-gui-unstable/debian.rules
+++ b/network:retroshare/retroshare-gui-unstable/debian.rules
@@ -36,7 +36,7 @@ install: build
 	#dh_installdirs
 	$(MAKE) INSTALL_ROOT=$(CURDIR)/debian/tmp install
 	# Remove bdboot.txt because it is shippend within retroshare-common
-	rm $(CURDIR)/debian/tmp/usr/share/retroshare/bdboot.txt
+	rm -f $(CURDIR)/debian/tmp/usr/share/retroshare/bdboot.txt
 
 # Build architecture-independent files here.
 binary-indep: build install

--- a/prepare_source_tarball.sh
+++ b/prepare_source_tarball.sh
@@ -35,10 +35,25 @@ ORIG_DIR="$(pwd)"
 	git -C ${SRC_DIR} submodule update --init supportlibs/rapidjson 
 }
 
+[ "$(ls "${SRC_DIR}/supportlibs/libsam3" | wc -l)" -lt "5" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init supportlibs/libsam3
+}
+
+[ "$(ls "${SRC_DIR}/supportlibs/cmark" | wc -l)" -lt "5" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init supportlibs/cmark
+}
+
+[ "$(ls "${SRC_DIR}/supportlibs/jni.hpp" | wc -l)" -lt "5" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init supportlibs/jni.hpp
+}
+
 cd "${WORK_DIR}"
 rsync -a --delete \
 	--exclude='.git' \
-	--filter=':- build_scripts/OBS/.gitignore' \
+	--exclude='.osc/*' \
 	"${SRC_DIR}/" RetroShare/
 
 ## Source_Version File

--- a/prepare_source_tarball.sh
+++ b/prepare_source_tarball.sh
@@ -50,6 +50,21 @@ ORIG_DIR="$(pwd)"
 	git -C ${SRC_DIR} submodule update --init supportlibs/jni.hpp
 }
 
+[ "$(ls "${SRC_DIR}/libbitdht" | wc -l)" -lt "1" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init --remote --force libbitdht
+}
+
+[ "$(ls "${SRC_DIR}/libretroshare" | wc -l)" -lt "1" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init --remote --force libretroshare
+}
+
+[ "$(ls "${SRC_DIR}/openpgpsdk" | wc -l)" -lt "1" ] &&
+{
+	git -C ${SRC_DIR} submodule update --init --remote --force openpgpsdk
+}
+
 cd "${WORK_DIR}"
 rsync -a --delete \
 	--exclude='.git' \


### PR DESCRIPTION
- Add missing submodule inits in prepare_source_tarball
- Don't use .gitignore in rsync, as it results in all .gitignore files being parsed, leaving Makefiles out of the tarball
- Ignore 'bdboot.txt' not existing in debian.rules when trying to remove it